### PR TITLE
Adding 1 sec sleep to prevent browser from fetching application url too early

### DIFF
--- a/lib/burn/cli.rb
+++ b/lib/burn/cli.rb
@@ -182,6 +182,9 @@ EOS
         run "#{command} &", :verbose => options[:verbose]
       end
       
+      # wait for certain period of time to prevent browser from fetching game url too early
+      sleep 1
+      
       # open up browser
       uri = "http://127.0.0.1:17890/emulator.html"
       browser = options[:chrome] ? "chrome" : "firefox"


### PR DESCRIPTION
It sometimes happens that firefox/chrome browser opens up too early to fetch application url successfully when user type `burn -p` or `burn play`.

This result in showing 404 error and it's not expected. #sleep(1) should be added into #play method.
