### PR TITLE
Resolve an issue compiling the complex sprite example

### DIFF
--- a/lib/burn/fuel/rom/scene.rb
+++ b/lib/burn/fuel/rom/scene.rb
@@ -103,7 +103,9 @@ module Burn
                 iChrCount+=1
               else
                 if c=='d' then
-                  @code_blocks.push sprintf("#{vname}[%d]=0x10+%s;", nmi_plots.index([x+iChrCount,y])*3+2, args.shift)
+                  shifted_arg = args.shift
+                  shifted_arg = shifted_arg.to_s.strip != '' ? "+#{shifted_arg}" : ''
+                  @code_blocks.push sprintf("#{vname}[%d]=0x10%s;", nmi_plots.index([x+iChrCount,y])*3+2, shifted_arg)
                   iChrCount+=1
                 elsif c=='s' then
                   args.shift.split(//).each do |d|


### PR DESCRIPTION
I noticed an issue compiling the "complex" sprite example.

With 1.9.3 and 2.1 I'd see this:

![banners_and_alerts_and_1__darrencauthon_darrens-macbook-air____desktop_burn_example_sprite_complex__zsh_](https://cloud.githubusercontent.com/assets/148768/7785257/96b7a25c-014d-11e5-994a-6cf869d37a0f.png)

![1__main_c____desktop_burn_example_sprite_complex_tmp_burn__-_vim__vim_](https://cloud.githubusercontent.com/assets/148768/7785261/be72ae18-014d-11e5-8be0-7a28c742eae5.png)

After this patch:

![menubar_and_main_rb_and_1__darrencauthon_darrens-macbook-air____desktop_burn_example_sprite_complex__zsh_](https://cloud.githubusercontent.com/assets/148768/7785306/0a932014-0150-11e5-9f9d-b2f1e64435cd.png)
