### PR TITLE
Add rake tasks for local gem building and installation.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,1 @@
-# TBD for test or build
+require "bundler/gem_tasks"

--- a/burn.gemspec
+++ b/burn.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |s|
   s.add_dependency "thor"
   s.add_dependency "archive-tar-minitar"
   s.add_dependency "eventmachine"
+
+  s.add_development_dependency "bundler", "~> 1.7"
   
   s.add_development_dependency "rake"
 end


### PR DESCRIPTION
I wanted to try to fix the complex sprite example.  

I wanted to verify my fix by installing the gem locally.  I've authored a few gems myself, and the default bundler rake tasks are pretty helpful.

This gives me:

`rake install`
